### PR TITLE
expose chunk_size as variable

### DIFF
--- a/deepmultilingualpunctuation/punctuationmodel.py
+++ b/deepmultilingualpunctuation/punctuationmodel.py
@@ -17,8 +17,8 @@ class PunctuationModel():
         text = text.split()
         return text
 
-    def restore_punctuation(self,text):        
-        result = self.predict(self.preprocess(text))
+    def restore_punctuation(self, text, chunk_size=230):        
+        result = self.predict(self.preprocess(text), chunk_size)
         return self.prediction_to_text(result)
         
     def overlap_chunks(self,lst, n, stride=0):
@@ -26,9 +26,8 @@ class PunctuationModel():
         for i in range(0, len(lst), n-stride):
                 yield lst[i:i + n]
 
-    def predict(self,words):
+    def predict(self, words, chunk_size=230):
         overlap = 5
-        chunk_size = 230
         if len(words) <= chunk_size:
             overlap = 0
 


### PR DESCRIPTION
Public API fix for https://github.com/oliverguhr/deepmultilingualpunctuation/issues/4 i.e.
```
Traceback (most recent call last):
line 49, in predict
    assert len(text) == result[-1]["end"], "chunk size too large, text got clipped"
AssertionError: chunk size too large, text got clipped
```

Closes https://github.com/oliverguhr/fullstop-deep-punctuation-prediction/issues/18